### PR TITLE
Upgraded SNAPSHOT dependencies to current releases to fix broken build

### DIFF
--- a/spring-data-orientdb-parent/pom.xml
+++ b/spring-data-orientdb-parent/pom.xml
@@ -13,25 +13,15 @@
 		<junit.version>4.10</junit.version>
 		<mockito.version>1.9.0</mockito.version>
 		<log4j.version>1.2.17</log4j.version>
-		<org.springframework.version.31>3.1.0.RELEASE</org.springframework.version.31>
+		<org.springframework.version.31>3.2.1.RELEASE</org.springframework.version.31>
 		<org.springframework.version.40>4.0.0.RELEASE</org.springframework.version.40>
-		<org.springframework.version.range>[${org.springframework.version.31},
-			${org.springframework.version.40})</org.springframework.version.range>
-		<data.commons.version>1.4.0.RC1</data.commons.version>
-		<data.jpa.version>1.1.0.RELEASE</data.jpa.version>
-		<orientdb.version>1.2.0</orientdb.version>
-		<data.orientdb.commons.version>0.0.1-SNAPSHOT</data.orientdb.commons.version>
+		<org.springframework.version.range>${org.springframework.version.31}</org.springframework.version.range>
+		<data.commons.version>1.4.1.RELEASE</data.commons.version>
+		<data.jpa.version>1.3.0.RELEASE</data.jpa.version>
+		<orientdb.version>1.3.0</orientdb.version>
 		<org.slf4j.version>1.6.1</org.slf4j.version>
-
+		<blueprints.version>2.2.0</blueprints.version>
 	</properties>
-
-	<repositories>
-		<repository>
-			<id>spring-milestone</id>
-			<name>Spring Maven MILESTONE Repository</name>
-			<url>http://maven.springframework.org/milestone</url>
-		</repository>
-	</repositories>
 
 	<dependencyManagement>
 		<dependencies>
@@ -99,7 +89,7 @@
 			<dependency>
 				<groupId>org.springframework.data</groupId>
 				<artifactId>spring-data-orientdb-commons</artifactId>
-				<version>${data.orientdb.commons.version}</version>
+				<version>${project.version}</version>
 			</dependency>
 
 
@@ -170,6 +160,40 @@
 				<version>${mockito.version}</version>
 				<scope>test</scope>
 			</dependency>
+
+			<dependency>
+				<groupId>com.tinkerpop.blueprints</groupId>
+				<artifactId>blueprints-core</artifactId>
+				<version>${blueprints.version}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>com.tinkerpop.blueprints</groupId>
+				<artifactId>blueprints-orient-graph</artifactId>
+				<version>${blueprints.version}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>com.tinkerpop</groupId>
+				<artifactId>pipes</artifactId>
+				<version>${blueprints.version}</version>
+				<type>jar</type>
+				<scope>compile</scope>
+			</dependency>
+
+			<dependency>
+				<groupId>com.tinkerpop.gremlin</groupId>
+				<artifactId>gremlin-java</artifactId>
+				<version>${blueprints.version}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>com.tinkerpop.gremlin</groupId>
+				<artifactId>gremlin-groovy</artifactId>
+				<version>${blueprints.version}</version>
+			</dependency>
+
+
 		</dependencies>
 	</dependencyManagement>
 


### PR DESCRIPTION
There were unresolvable SNAPSHOT dependencies on Blueprints and Spring.
