### PR TITLE
squid:S2293, squid:S1118 - The diamond operator should be used, Utili…

### DIFF
--- a/spring-data-orientdb-commons/src/main/java/org/springframework/data/orient/commons/repository/query/JooqUtils.java
+++ b/spring-data-orientdb-commons/src/main/java/org/springframework/data/orient/commons/repository/query/JooqUtils.java
@@ -6,7 +6,11 @@ import org.jooq.SQLDialect;
 import org.jooq.SelectJoinStep;
 import org.jooq.impl.DSL;
 
-public class JooqUtils {
+public final class JooqUtils {
+
+    private JooqUtils() throws InstantiationException {
+        throw new InstantiationException("This class is not for instantiation");
+    }
 
     public static DSLContext context() {
         return DSL.using(SQLDialect.MYSQL);

--- a/spring-data-orientdb-commons/src/main/java/org/springframework/data/orient/commons/repository/query/OrientQueryCreator.java
+++ b/spring-data-orientdb-commons/src/main/java/org/springframework/data/orient/commons/repository/query/OrientQueryCreator.java
@@ -169,7 +169,7 @@ public class OrientQueryCreator extends AbstractQueryCreator<String, Condition> 
             return Collections.emptyList();
         }
         
-        List<Object> list = new ArrayList<Object>();
+        List<Object> list = new ArrayList<>();
         while (iterator.hasNext()) {
             list.add(iterator.next());
         }
@@ -178,7 +178,7 @@ public class OrientQueryCreator extends AbstractQueryCreator<String, Condition> 
     }
     
     private List<SortField<?>> toOrders(Sort sort) {
-        List<SortField<?>> orders = new ArrayList<SortField<?>>();
+        List<SortField<?>> orders = new ArrayList<>();
         
         for (Order order : sort) {
             orders.add(field(order.getProperty()).sort(order.getDirection() == Direction.ASC ? SortOrder.ASC : SortOrder.DESC)); 

--- a/spring-data-orientdb-commons/src/main/java/org/springframework/data/orient/commons/repository/query/QueryUtils.java
+++ b/spring-data-orientdb-commons/src/main/java/org/springframework/data/orient/commons/repository/query/QueryUtils.java
@@ -53,7 +53,7 @@ public final class QueryUtils {
             return Collections.emptyList();
         }
         
-        List<SortField<?>> orders = new ArrayList<SortField<?>>();
+        List<SortField<?>> orders = new ArrayList<>();
         
         for (Order order : sort) {
             orders.add(field(order.getProperty()).sort(order.getDirection() == Direction.ASC ? SortOrder.ASC : SortOrder.DESC)); 

--- a/spring-data-orientdb-commons/src/main/java/org/springframework/data/orient/commons/repository/support/OrientRepositoryFactory.java
+++ b/spring-data-orientdb-commons/src/main/java/org/springframework/data/orient/commons/repository/support/OrientRepositoryFactory.java
@@ -43,7 +43,7 @@ public class OrientRepositoryFactory extends RepositoryFactorySupport {
     @Override
     @SuppressWarnings("unchecked")
     public <T, ID extends Serializable> EntityInformation<T, ID> getEntityInformation(Class<T> domainClass) {
-        return (EntityInformation<T, ID>) new OrientMetamodelEntityInformation<T>(domainClass);
+        return (EntityInformation<T, ID>) new OrientMetamodelEntityInformation<>(domainClass);
     }
 
     @Override

--- a/spring-data-orientdb-commons/src/main/java/org/springframework/data/orient/commons/repository/support/SimpleOrientRepository.java
+++ b/spring-data-orientdb-commons/src/main/java/org/springframework/data/orient/commons/repository/support/SimpleOrientRepository.java
@@ -52,7 +52,7 @@ public class SimpleOrientRepository<T> implements OrientRepository<T> {
      * @param repositoryInterface the target repository interface
      */
     public SimpleOrientRepository(OrientOperations operations, Class<T> domainClass, Class<?> repositoryInterface) {
-        this(operations, domainClass, repositoryInterface, new SimpleOrientStrategy<T>(operations, domainClass));
+        this(operations, domainClass, repositoryInterface, new SimpleOrientStrategy<>(operations, domainClass));
     }
 
     /**
@@ -109,7 +109,7 @@ public class SimpleOrientRepository<T> implements OrientRepository<T> {
             return Collections.emptyList();
         }
 
-        List<S> result = new ArrayList<S>();
+        List<S> result = new ArrayList<>();
 
         for (S entity : entities) {
             result.add(save(entity));
@@ -124,7 +124,7 @@ public class SimpleOrientRepository<T> implements OrientRepository<T> {
             return Collections.emptyList();
         }
 
-        List<S> result = new ArrayList<S>();
+        List<S> result = new ArrayList<>();
 
         for (S entity : entities) {
             result.add(save(entity, cluster));
@@ -312,13 +312,13 @@ public class SimpleOrientRepository<T> implements OrientRepository<T> {
     @SuppressWarnings("unchecked")
     public Page<T> findAll(Pageable pageable) {
         if (pageable == null) {
-            return new PageImpl<T>(findAll());
+            return new PageImpl<>(findAll());
         }
 
         Long total = count();
         List<T> content = (List<T>) (total > pageable.getOffset() ? operations.query(getQuery(pageable)) : Collections.<T> emptyList());
 
-        return new PageImpl<T>(content, pageable, total);
+        return new PageImpl<>(content, pageable, total);
     }
 
     /**
@@ -341,7 +341,7 @@ public class SimpleOrientRepository<T> implements OrientRepository<T> {
     private OSQLQuery<T> getQuery(String source, Sort sort) {
         Query query = DSL.using(SQLDialect.MYSQL).select().from(source).orderBy(QueryUtils.toOrders(sort));
 
-        return new OSQLSynchQuery<T>(query.getSQL(ParamType.INLINED));
+        return new OSQLSynchQuery<>(query.getSQL(ParamType.INLINED));
     }
 
     /**
@@ -358,6 +358,6 @@ public class SimpleOrientRepository<T> implements OrientRepository<T> {
         SelectLimitStep<? extends Record> limitStep = sort == null ? joinStep : joinStep.orderBy(QueryUtils.toOrders(sort));
         Query query = pageable == null ? limitStep : limitStep.limit(pageable.getPageSize()).offset(pageable.getOffset());
         
-        return new OSQLSynchQuery<T>(query.getSQL(ParamType.INLINED));
+        return new OSQLSynchQuery<>(query.getSQL(ParamType.INLINED));
     }
 }

--- a/spring-data-orientdb-object/src/main/java/org/springframework/data/orient/object/repository/support/OrientObjectRepositoryFactory.java
+++ b/spring-data-orientdb-object/src/main/java/org/springframework/data/orient/object/repository/support/OrientObjectRepositoryFactory.java
@@ -30,7 +30,7 @@ public class OrientObjectRepositoryFactory extends RepositoryFactorySupport {
     @Override
     @SuppressWarnings("unchecked")
     public <T, ID extends Serializable> EntityInformation<T, ID> getEntityInformation(Class<T> domainClass) {
-        return (EntityInformation<T, ID>) new OrientMetamodelEntityInformation<T>(domainClass);
+        return (EntityInformation<T, ID>) new OrientMetamodelEntityInformation<>(domainClass);
     }
 
     @Override

--- a/spring-data-orientdb-samples/spring-boot-orientdb-hello/src/main/java/org/springframework/boot/orientdb/hello/HelloApplication.java
+++ b/spring-data-orientdb-samples/spring-boot-orientdb-hello/src/main/java/org/springframework/boot/orientdb/hello/HelloApplication.java
@@ -48,7 +48,7 @@ public class HelloApplication implements CommandLineRunner {
         
         //Create Persons if required
         if (repository.count() < 1) {
-            List<Person> persons = new ArrayList<Person>();
+            List<Person> persons = new ArrayList<>();
             
             Person graham = new Person();
             graham.setFirstName("Graham");

--- a/spring-data-orientdb-samples/spring-boot-orientdb-shiro/src/main/java/org/springframework/boot/orient/sample/shiro/Application.java
+++ b/spring-data-orientdb-samples/spring-boot-orientdb-shiro/src/main/java/org/springframework/boot/orient/sample/shiro/Application.java
@@ -18,7 +18,11 @@ import org.springframework.context.annotation.ComponentScan;
 
 @EnableAutoConfiguration
 @ComponentScan
-public class Application {
+public final class Application {
+
+    private Application() throws InstantiationException {
+        throw new InstantiationException("This class is not for instantiation");
+    }
 
     public static void main(String... args) {
         new SpringApplicationBuilder()


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules squid:S2293 - The diamond operator ("<>") should be used
squid:S1118 - Utility classes should not have public constructors

You can find more information about the issues here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S2293
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1118

Please let me know if you have any questions.

M-Ezzat