### PR TITLE
Cleanup - squid:S1312 - Loggers should be "private static final" and …

### DIFF
--- a/spring-data-orientdb-commons/src/main/java/org/springframework/data/orient/commons/core/AbstractOrientDatabaseFactory.java
+++ b/spring-data-orientdb-commons/src/main/java/org/springframework/data/orient/commons/core/AbstractOrientDatabaseFactory.java
@@ -19,7 +19,7 @@ import static org.springframework.util.Assert.notNull;
 public abstract class AbstractOrientDatabaseFactory<T> implements OrientDatabaseFactory<T> {
 
     /** The logger. */
-    private static Logger log = LoggerFactory.getLogger(AbstractOrientDatabaseFactory.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractOrientDatabaseFactory.class);
 
     /** The username. */
     protected String username = DEFAULT_USERNAME;
@@ -67,15 +67,15 @@ public abstract class AbstractOrientDatabaseFactory<T> implements OrientDatabase
         ODatabase<T> db;
         if(!ODatabaseRecordThreadLocal.INSTANCE.isDefined()) {
             db = openDatabase();
-            log.debug("acquire db from pool {}", db.hashCode());
+            LOGGER.debug("acquire db from pool {}", db.hashCode());
         } else {
             db = (ODatabase<T>)ODatabaseRecordThreadLocal.INSTANCE.get().getDatabaseOwner();
 
             if(db.isClosed()) {
                 db = openDatabase();
-                log.debug("re-opened db {}", db.hashCode());
+                LOGGER.debug("re-opened db {}", db.hashCode());
             } else {
-                log.debug("use existing db {}", db.hashCode());
+                LOGGER.debug("use existing db {}", db.hashCode());
             }
         }
 

--- a/spring-data-orientdb-commons/src/main/java/org/springframework/data/orient/commons/core/OrientTransactionManager.java
+++ b/spring-data-orientdb-commons/src/main/java/org/springframework/data/orient/commons/core/OrientTransactionManager.java
@@ -24,7 +24,7 @@ public class OrientTransactionManager extends AbstractPlatformTransactionManager
     private static final long serialVersionUID = 1L;
 
     /** The logger. */
-    private static Logger log = LoggerFactory.getLogger(OrientTransactionManager.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(OrientTransactionManager.class);
 
     /** The database factory. */
     private OrientDatabaseFactory<?> dbf;
@@ -80,7 +80,7 @@ public class OrientTransactionManager extends AbstractPlatformTransactionManager
             TransactionSynchronizationManager.bindResource(dbf, db);
         }
         
-        log.debug("beginning transaction, db.hashCode() = {}", db.hashCode());
+        LOGGER.debug("beginning transaction, db.hashCode() = {}", db.hashCode());
         
         db.begin();
     }
@@ -93,7 +93,7 @@ public class OrientTransactionManager extends AbstractPlatformTransactionManager
         OrientTransaction tx = (OrientTransaction) status.getTransaction();
         ODatabase<?> db = tx.getDatabase();
         
-        log.debug("committing transaction, db.hashCode() = {}", db.hashCode());
+        LOGGER.debug("committing transaction, db.hashCode() = {}", db.hashCode());
         
         db.commit();
     }
@@ -106,7 +106,7 @@ public class OrientTransactionManager extends AbstractPlatformTransactionManager
         OrientTransaction tx = (OrientTransaction) status.getTransaction();
         ODatabase<?> db = tx.getDatabase();
         
-        log.debug("rolling back transaction, db.hashCode() = {}", db.hashCode());
+        LOGGER.debug("rolling back transaction, db.hashCode() = {}", db.hashCode());
         
         db.rollback();
     }
@@ -127,7 +127,7 @@ public class OrientTransactionManager extends AbstractPlatformTransactionManager
         OrientTransaction tx = (OrientTransaction) transaction;
         
         if (!tx.getDatabase().isClosed()) {
-            log.debug("closing transaction, db.hashCode() = {}", tx.getDatabase().hashCode());
+            LOGGER.debug("closing transaction, db.hashCode() = {}", tx.getDatabase().hashCode());
             tx.getDatabase().close();
         }
         

--- a/spring-data-orientdb-commons/src/main/java/org/springframework/data/orient/commons/repository/query/OrientQueryCreator.java
+++ b/spring-data-orientdb-commons/src/main/java/org/springframework/data/orient/commons/repository/query/OrientQueryCreator.java
@@ -28,7 +28,7 @@ import static org.jooq.impl.DSL.field;
 
 public class OrientQueryCreator extends AbstractQueryCreator<String, Condition> {
     
-    private static final Logger logger = LoggerFactory.getLogger(OrientQueryCreator.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(OrientQueryCreator.class);
     
     private final DSLContext context;
     
@@ -100,7 +100,7 @@ public class OrientQueryCreator extends AbstractQueryCreator<String, Condition> 
         //String queryString = query.getSQL(paramType);
         //Use inline parameters for paged queries
         String queryString = query.getSQL(ParamType.INLINED);
-        logger.debug(queryString);
+        LOGGER.debug(queryString);
         
         return queryString;
     }

--- a/spring-data-orientdb-samples/spring-boot-orientdb-shiro/src/main/java/org/springframework/boot/orient/sample/shiro/rest/UserController.java
+++ b/spring-data-orientdb-samples/spring-boot-orientdb-shiro/src/main/java/org/springframework/boot/orient/sample/shiro/rest/UserController.java
@@ -42,7 +42,7 @@ import static org.springframework.web.bind.annotation.RequestMethod.*;
 @RequestMapping("/users")
 public class UserController {
 
-    private static final Logger log = LoggerFactory.
+    private static final Logger LOGGER = LoggerFactory.
             getLogger(UserController.class);
 
     @Autowired
@@ -59,7 +59,7 @@ public class UserController {
 
     @RequestMapping(value = "/auth", method = POST)
     public void authenticate(@RequestBody final UsernamePasswordToken credentials) {
-        log.info("Authenticating {} with password {}", credentials.getUsername(),
+        LOGGER.info("Authenticating {} with password {}", credentials.getUsername(),
                 credentials.getPassword());
         final Subject subject = SecurityUtils.getSubject();
         subject.login(credentials);
@@ -83,7 +83,7 @@ public class UserController {
 
     @RequestMapping(method = PUT)
     public void initScenario() {
-        log.info("Initializing scenario..");
+        LOGGER.info("Initializing scenario..");
         // clean-up users, roles and permissions
         userRepo.deleteAll();
         roleRepo.deleteAll();
@@ -109,7 +109,7 @@ public class UserController {
         user.setPassword(passwordService.encryptPassword("123qwe"));
         user.getRoles().add(roleAdmin);
         userRepo.save(user);
-        log.info("Scenario initiated.");
+        LOGGER.info("Scenario initiated.");
     }
 
 }

--- a/spring-data-orientdb-samples/spring-boot-orientdb-shiro/src/main/java/org/springframework/boot/orient/sample/shiro/shiro/HazelcastSessionDao.java
+++ b/spring-data-orientdb-samples/spring-boot-orientdb-shiro/src/main/java/org/springframework/boot/orient/sample/shiro/shiro/HazelcastSessionDao.java
@@ -31,7 +31,7 @@ import java.util.UUID;
  */
 public class HazelcastSessionDao extends AbstractSessionDAO {
 
-    private static final Logger log = LoggerFactory
+    private static final Logger LOGGER = LoggerFactory
             .getLogger(HazelcastSessionDao.class);
 
     private final String hcInstanceName = UUID.randomUUID().toString();
@@ -44,7 +44,7 @@ public class HazelcastSessionDao extends AbstractSessionDAO {
     private static final int HC_MULTICAST_PORT = 54327;
 
     public HazelcastSessionDao() {
-        log.info("Initializing Hazelcast Shiro session persistence..");
+        LOGGER.info("Initializing Hazelcast Shiro session persistence..");
 
         // configure Hazelcast instance
         final Config cfg = new Config();
@@ -74,13 +74,13 @@ public class HazelcastSessionDao extends AbstractSessionDAO {
 
         // get map
         map = Hazelcast.newHazelcastInstance(cfg).getMap(HC_MAP);
-        log.info("Hazelcast Shiro session persistence initialized.");
+        LOGGER.info("Hazelcast Shiro session persistence initialized.");
     }
 
     @Override
     protected Serializable doCreate(Session session) {
         final Serializable sessionId = generateSessionId(session);
-        log.debug("Creating a new session identified by[{}]", sessionId);
+        LOGGER.debug("Creating a new session identified by[{}]", sessionId);
         assignSessionId(session, sessionId);
         map.put(session.getId(), session);
 
@@ -89,19 +89,19 @@ public class HazelcastSessionDao extends AbstractSessionDAO {
 
     @Override
     protected Session doReadSession(Serializable sessionId) {
-        log.debug("Reading a session identified by[{}]", sessionId);
+        LOGGER.debug("Reading a session identified by[{}]", sessionId);
         return map.get(sessionId);
     }
 
     @Override
     public void update(Session session) throws UnknownSessionException {
-        log.debug("Updating a session identified by[{}]", session.getId());
+        LOGGER.debug("Updating a session identified by[{}]", session.getId());
         map.replace(session.getId(), session);
     }
 
     @Override
     public void delete(Session session) {
-        log.debug("Deleting a session identified by[{}]", session.getId());
+        LOGGER.debug("Deleting a session identified by[{}]", session.getId());
         map.remove(session.getId());
     }
 
@@ -119,7 +119,7 @@ public class HazelcastSessionDao extends AbstractSessionDAO {
      */
     public Collection<Session> getSessionsForAuthenticationEntity(
             final String email) {
-        log.debug("Looking up for sessions related to [{}]", email);
+        LOGGER.debug("Looking up for sessions related to [{}]", email);
         final SessionAttributePredicate<String> predicate
                 = new SessionAttributePredicate<>("email", email);
         return map.values(predicate);
@@ -129,7 +129,7 @@ public class HazelcastSessionDao extends AbstractSessionDAO {
      * Destroys currently allocated instance.
      */
     public void destroy() {
-        log.info("Shutting down Hazelcast instance [{}]..", hcInstanceName);
+        LOGGER.info("Shutting down Hazelcast instance [{}]..", hcInstanceName);
         final HazelcastInstance instance = Hazelcast.getHazelcastInstanceByName(
                 hcInstanceName);
         if (instance != null) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1312 - Loggers should be "private static final" and should share a naming convention

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1312

Please let me know if you have any questions.

M-Ezzat