### PR TITLE
Added deleteBy support.  The repository method must provide a valid a…

### DIFF
--- a/spring-data-orientdb-commons/src/main/java/org/springframework/data/orient/commons/repository/query/AbstractOrientQuery.java
+++ b/spring-data-orientdb-commons/src/main/java/org/springframework/data/orient/commons/repository/query/AbstractOrientQuery.java
@@ -5,6 +5,7 @@ import org.springframework.data.orient.commons.core.OrientOperations;
 import org.springframework.data.orient.commons.repository.DetachMode;
 import org.springframework.data.orient.commons.repository.query.OrientQueryExecution.CollectionExecution;
 import org.springframework.data.orient.commons.repository.query.OrientQueryExecution.CountExecution;
+import org.springframework.data.orient.commons.repository.query.OrientQueryExecution.DeleteExecution;
 import org.springframework.data.orient.commons.repository.query.OrientQueryExecution.PagedExecution;
 import org.springframework.data.orient.commons.repository.query.OrientQueryExecution.SingleEntityExecution;
 import org.springframework.data.repository.query.RepositoryQuery;
@@ -114,7 +115,11 @@ public abstract class AbstractOrientQuery implements RepositoryQuery {
             return new PagedExecution(operations, parameters);
         } else if (method.isQueryForEntity()) {
             return new SingleEntityExecution(operations, parameters);
-        } 
+        } else if (method.getName().startsWith("deleteBy")) {
+            //using deleteBy prefix in method name since method object does not 
+            //have a flag to indicate if method is for delete operation
+            return new DeleteExecution(method.getAnnotatedQuery(), operations, parameters);
+        }
         
         throw new IllegalArgumentException();
     }

--- a/spring-data-orientdb-commons/src/main/java/org/springframework/data/orient/commons/repository/query/OrientQueryExecution.java
+++ b/spring-data-orientdb-commons/src/main/java/org/springframework/data/orient/commons/repository/query/OrientQueryExecution.java
@@ -74,6 +74,36 @@ public abstract class OrientQueryExecution {
             return operations.query(query.createQuery(values), mode, prepareParameters(parameters, values));
         }
     }
+    
+    /**
+     * Executes a delete operation using provided @query method annotation.
+     * 
+     * @author Ronnie Andrews, Jr.
+     */
+    static class DeleteExecution extends OrientQueryExecution {
+        
+        private String sql;
+
+        /**
+         * Instantiates a new {@link DeleteExecution}.
+         *
+         * @param template the template
+         */
+        public DeleteExecution(String sql, OrientOperations template, OrientParameters parameters) {
+            
+            super(template, parameters);
+            this.sql = sql;
+        }
+
+        /* (non-Javadoc)
+         * @see org.springframework.data.orient.repository.object.query.OrientQueryExecution#doExecute(org.springframework.data.orient.repository.object.query.AbstractOrientQuery, java.lang.Object[])
+         */
+        @Override
+        @SuppressWarnings("unchecked")
+        protected Object doExecute(AbstractOrientQuery query, DetachMode mode, Object[] values) {
+            return operations.command(this.sql, values);
+        }
+    }
 
     /**
      * Executes a {@link AbstractOrientQuery} to return a single entity.

--- a/spring-data-orientdb-commons/src/main/java/org/springframework/data/orient/commons/repository/query/StringBasedOrientQuery.java
+++ b/spring-data-orientdb-commons/src/main/java/org/springframework/data/orient/commons/repository/query/StringBasedOrientQuery.java
@@ -14,7 +14,11 @@ public class StringBasedOrientQuery extends AbstractOrientQuery {
     public StringBasedOrientQuery(String query, OrientQueryMethod method, OrientOperations operations) {
         super(method, operations);
         this.queryString = query;
-        this.isCountQuery = method.hasAnnotatedQuery() ? method.getQueryAnnotation().count() : false;
+        
+        //if method starts with countBy, it is Spring Data countBy method, 
+        //otherwise do regular check
+        this.isCountQuery = (method.getMethod().getName().startsWith("countBy")) ? 
+            true : ((method.hasAnnotatedQuery()) ? method.getQueryAnnotation().count() : false);
     }
 
     @Override

--- a/spring-data-orientdb-samples/spring-boot-orientdb-hello/src/main/java/org/springframework/boot/orientdb/hello/HelloApplication.java
+++ b/spring-data-orientdb-samples/spring-boot-orientdb-hello/src/main/java/org/springframework/boot/orientdb/hello/HelloApplication.java
@@ -87,5 +87,8 @@ public class HelloApplication implements CommandLineRunner {
             
             repository.save(persons);
         }
+        
+        //test deleteBy operation by removing Kaitlin
+        Long numDeleted = repository.deleteByAge(22);
     }
 }

--- a/spring-data-orientdb-samples/spring-boot-orientdb-hello/src/main/java/org/springframework/boot/orientdb/hello/HelloApplication.java
+++ b/spring-data-orientdb-samples/spring-boot-orientdb-hello/src/main/java/org/springframework/boot/orientdb/hello/HelloApplication.java
@@ -88,6 +88,12 @@ public class HelloApplication implements CommandLineRunner {
             repository.save(persons);
         }
         
+        //test countBy operation using generated query
+        Long countByAge = repository.countByAge(22);
+        
+        //test countBy operation using the annotated query provided
+        Long countByAgeWithAnnotatedQuery = repository.countByAgeWithAnnotatedQuery(22);
+        
         //test deleteBy operation by removing Kaitlin
         Long numDeleted = repository.deleteByAge(22);
     }

--- a/spring-data-orientdb-samples/spring-boot-orientdb-hello/src/main/java/org/springframework/boot/orientdb/hello/repository/PersonRepository.java
+++ b/spring-data-orientdb-samples/spring-boot-orientdb-hello/src/main/java/org/springframework/boot/orientdb/hello/repository/PersonRepository.java
@@ -14,4 +14,7 @@ public interface PersonRepository extends OrientObjectRepository<Person> {
     List<Person> findByLastName(String lastName);
     
     List<Person> findByAge(Integer age);
+    
+    @Query("delete from Person where age = ?")
+    Long deleteByAge(Integer age);
 }

--- a/spring-data-orientdb-samples/spring-boot-orientdb-hello/src/main/java/org/springframework/boot/orientdb/hello/repository/PersonRepository.java
+++ b/spring-data-orientdb-samples/spring-boot-orientdb-hello/src/main/java/org/springframework/boot/orientdb/hello/repository/PersonRepository.java
@@ -17,4 +17,9 @@ public interface PersonRepository extends OrientObjectRepository<Person> {
     
     @Query("delete from Person where age = ?")
     Long deleteByAge(Integer age);
+    
+    Long countByAge(Integer age);
+    
+    @Query("select count(*) from Person where age = ?")
+    Long countByAgeWithAnnotatedQuery(Integer age);
 }


### PR DESCRIPTION
Added deleteBy support. The repository method must provide a valid annotated query/command for the delete operation. Such as:

@Query("delete from Person where age = ?")
Long deleteByAge(Integer age);

Also updated the Hello example to include a deleteByAge operation for reference.  Please note deleteBy annotated SQL must be valid such was "delete from XYZ" or "delete vertex from XYZ" depending on whether you are deleting a vertex or not.